### PR TITLE
fix(v2): add resizeToAvoidBottomInset: false to PortoneWebView Scaffold

### DIFF
--- a/lib/v2/widget/portone_webview.dart
+++ b/lib/v2/widget/portone_webview.dart
@@ -68,6 +68,12 @@ class _PortoneWebViewState extends State<PortoneWebView> {
         }
       },
       child: Scaffold(
+        // bugfix: Scroll issue on iOS when focusing on a text field in WebView.
+        // Mirror of PR #143 (V1 IamportWebView fix) for V2 PortoneWebView.
+        // Without this, virtual keyboard appearance shifts the entire WebView
+        // upward causing input field to be hidden behind keyboard accessory bar.
+        // See issue #123.
+        resizeToAvoidBottomInset: false,
         appBar: widget.appBar,
         body: SafeArea(
           child: IndexedStack(


### PR DESCRIPTION
## Summary

Mirrors [PR #143](https://github.com/portone-io/portone_flutter/pull/143) (V1 `IamportWebView` fix) for V2 `PortoneWebView`. Without `resizeToAvoidBottomInset: false`, the virtual keyboard appearance on iOS shifts the entire WebView upward, causing the focused input field to be hidden behind the keyboard accessory bar.

Setting `resizeToAvoidBottomInset: false` defers viewport adjustment to the WebView/HTML — PG forms (Danal PASS, KG inicis, etc.) typically have their own scroll-into-view handling on focus events.

## Fixes

- Closes #123 (아이폰 키보드 포커스 이동시 화면 내려가는 현상)

## Test plan

- [x] Reproduced on iOS 26.5 (Xcode 26.5) before the patch — Danal PASS identity verification flow had input field hidden behind keyboard accessory bar after focus
- [x] After patch — input field remains visible above keyboard across all PASS form pages (name / DOB / phone selection)
- [x] No regression on Android (keyboard handling unchanged on Android)
- [x] `flutter analyze` passes

## Notes

- 1-line behavioral change, no breaking API
- Matches V1 fix pattern from PR #143 — same intent for V2

🤖 Generated with [Claude Code](https://claude.com/claude-code)