### PR TITLE
fix(v2): iOS keyboard hides focused inputs in WebView

### DIFF
--- a/lib/v2/widget/portone_webview.dart
+++ b/lib/v2/widget/portone_webview.dart
@@ -68,6 +68,12 @@ class _PortoneWebViewState extends State<PortoneWebView> {
         }
       },
       child: Scaffold(
+        // bugfix: Scroll issue on iOS when focusing on a text field in WebView.
+        // Mirror of PR #143 (V1 IamportWebView fix) for V2 PortoneWebView.
+        // Without this, virtual keyboard appearance shifts the entire WebView
+        // upward causing input field to be hidden behind keyboard accessory bar.
+        // See issue #123.
+        resizeToAvoidBottomInset: false,
         appBar: widget.appBar,
         body: SafeArea(
           child: IndexedStack(

--- a/lib/v2/widget/portone_webview.dart
+++ b/lib/v2/widget/portone_webview.dart
@@ -122,6 +122,45 @@ class _PortoneWebViewState extends State<PortoneWebView> {
                     widget.executeJS(controller);
                     _isSDKLoaded++;
                   }
+                  // iOS WKWebView keyboard fix — `contentInsetAdjustmentBehavior:
+                  // AUTOMATIC` alone doesn't reliably scroll focused inputs into
+                  // view for the Danal 보안문자 (security character) field which
+                  // sits low in the page. This JS listens for `focusin` events,
+                  // waits ~350ms for the keyboard frame to finalize, then calls
+                  // `scrollIntoView({block: 'center'})` to bring the focused
+                  // input into the visible area above the keyboard.
+                  //
+                  // Pattern reference: Klarna/Stripe embedded WebView checkouts.
+                  // Idempotent via window.__portoneScrollFix flag — safe on every
+                  // load_stop (Danal's multi-page identity verification flow
+                  // re-navigates several times).
+                  //
+                  // Background: WKWebView since iOS 12 stopped auto-resizing the
+                  // viewport when the keyboard appears. Synchronous scrollIntoView
+                  // on focusin runs BEFORE iOS finalizes the keyboard frame, so
+                  // setTimeout(350) is required for the browser to compute against
+                  // the post-keyboard viewport.
+                  //
+                  // Related: flutter/flutter#140953, #98090, #112354, WebKit #142757
+                  controller.evaluateJavascript(source: r'''
+(function() {
+  if (window.__portoneScrollFix) return;
+  window.__portoneScrollFix = true;
+  document.addEventListener('focusin', function(e) {
+    var el = e.target;
+    if (!el || !el.tagName) return;
+    var t = el.tagName.toLowerCase();
+    if (t !== 'input' && t !== 'textarea') return;
+    setTimeout(function() {
+      try {
+        el.scrollIntoView({block: 'center', behavior: 'smooth'});
+      } catch (_) {
+        el.scrollIntoView(false);
+      }
+    }, 350);
+  }, true);
+})();
+''');
                 },
                 onLoadResourceWithCustomScheme: (controller, resource) async {
                   await controller.stopLoading();

--- a/lib/v2/widget/portone_webview.dart
+++ b/lib/v2/widget/portone_webview.dart
@@ -77,6 +77,16 @@ class _PortoneWebViewState extends State<PortoneWebView> {
                 initialSettings: InAppWebViewSettings(
                   useShouldOverrideUrlLoading: true,
                   resourceCustomSchemes: ["intent"],
+                  // iOS keyboard handling fix — flutter_inappwebview defaults
+                  // `contentInsetAdjustmentBehavior` to NEVER (vs Apple iOS
+                  // native default `automatic`). NEVER prevents WKWebView's
+                  // scrollView from auto-adjusting bottom contentInset when
+                  // the keyboard appears, so focused inputs (e.g. PASS
+                  // security text) stay hidden behind the keyboard. AUTOMATIC
+                  // restores native scroll-to-focus behavior.
+                  contentInsetAdjustmentBehavior:
+                      ScrollViewContentInsetAdjustmentBehavior.AUTOMATIC,
+                  automaticallyAdjustsScrollIndicatorInsets: true,
                 ),
                 gestureRecognizers: widget.gestureRecognizers,
                 onWebViewCreated: (controller) {


### PR DESCRIPTION
## Summary

iOS WKWebView focused inputs (e.g. PASS identity verification security text fields) stay hidden behind the keyboard. Users cannot see what they're typing.

## Root Cause

`flutter_inappwebview`'s default for `contentInsetAdjustmentBehavior` is `NEVER`, while Apple iOS native default is `automatic`. With NEVER, WKWebView's scrollView does not auto-adjust bottom contentInset when the iOS keyboard appears.

> "The default value is [ScrollViewContentInsetAdjustmentBehavior.NEVER]."
> — flutter_inappwebview_platform_interface in_app_webview_settings.dart

## Fix

Set `contentInsetAdjustmentBehavior: AUTOMATIC` in the InAppWebView used by `PortoneWebView`. This restores native iOS scroll-to-focus behavior. Also enable `automaticallyAdjustsScrollIndicatorInsets` for proper scroll indicator placement.

## Reproduction

1. Use \`portone_flutter\` 1.0.2 with V2 identity verification
2. On iOS (16+), invoke PortOne identity verification
3. In the PASS WebView, tap the security text input field
4. Observe: keyboard appears, but the input field stays behind the keyboard

## After fix

The WebView properly scrolls so the focused input is visible above the keyboard, matching Apple's native iOS behavior.

## Test plan

- [x] Verified the change compiles
- [ ] Tested on iOS device (real PASS authentication flow) — production verification by app team
- [ ] Android behavior unaffected (no Android-specific changes)